### PR TITLE
feat:set-preset1(monitor1)

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,13 +74,14 @@ def ping_monitoring3():
             eel.update_ping_result3(result3)
 
 @eel.expose
-def save_request():
-    response = requests.get(
-         'http://192.168.11.240/cgi-bin/camposiset?presetset=1',
+def save_request(ip_address):
+    response1 = requests.get(
+         f'http://{ip_address}/cgi-bin/camposiset?presetset=1',
          auth=HTTPDigestAuth("nwcadmin", "Passwd34"))
-    print(response)
-    print(response.status_code)
-    print(response.text)
+
+    print(response1)
+    print(response1.status_code)
+    print(response1.text)
 
 if __name__ == "__main__":
     eel.start("index.html", size=(2000,3500))

--- a/web/main.js
+++ b/web/main.js
@@ -98,10 +98,13 @@ const saveAngle1Btn = document.getElementById('save-angle1') // first-angle-btn
 const saveAngle2Btn = document.getElementById('save-angle2')
 const saveAngle3Btn = document.getElementById('save-angle3')
 
+eel.expose(save_request_preset1)
 saveAngle1Btn.addEventListener('click', () => {
-  eel.save_request();
-  // cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camposiset?presetset=1"
+  save_request_preset1(ipAddressInput.value);
 });
+  function save_request_preset1(ipAddress){
+    eel.save_request(ipAddress);
+};
 
 saveAngle2Btn.addEventListener('click', () => {
   cameraViewer.src = "http://nwcadmin:Passwd34@" + ipAddressInput.value + "/cgi-bin/camposiset?presetset=2"


### PR DESCRIPTION
#14 
### 現状
１番上のモニターのプリセット１のみ保存ができる。入力されたIPアドレスを読み込む。
（同様のコードを羅列していけば、記述は汚いが、全ての実装はできる）

### 理想
綺麗なコードでプリセットの値保存を実装。