### PR TITLE
feat:brighter-darken-btn

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -57,6 +57,9 @@
       <h4 class="sukkiri">比率</h4>
       <button class="ifr-resize-btn sukkiri" id="wide-frame-size">①</button>
       <button class="sukkiri ifr-resize-btn" id="small-frame-size">②</button>
+      <h4 class="sukkiri">明るさ</h4>
+      <button class="light-btn sukkiri" id="light-btn">明</button>
+      <button class="dark-btn sukkiri" id="dark-btn">暗</button>
     </div>
     <div class="ping-panel sukkiri">
       <div class="online-status-indicatators sukkiri"></div>
@@ -77,6 +80,8 @@
         <button class="side-btn" id="side-down">↓</button>
         <button class="side-btn" id="side-left">←</button>
         <button class="side-btn" id="side-right">→</button>
+        <button class="side-btn" id="side-light">明</button>
+        <button class="side-btn" id="side-dark">暗</button>
       </div>
       <iframe id="camera-viewer" class="iframe"
         src="http://{ipAddress}/ImageViewer?Mode=Motion&Resolution=640x360&Quality=Motion&Interval=10" scrolling="no">
@@ -117,6 +122,9 @@
     <h4 class="sukkiri">比率</h4>
     <button class="ifr-resize-btn sukkiri" id="wide-frame-size2">①</button>
     <button class="sukkiri ifr-resize-btn" id="small-frame-size2">②</button>
+    <h4 class="sukkiri">明るさ</h4>
+    <button class="light-btn sukkiri" id="light-btn2">明</button>
+    <button class="dark-btn sukkiri" id="dark-btn2">暗</button>
   </div>
   <div class="ping-panel sukkiri">
     <div class="online-status-indicatators2 sukkiri"></div>
@@ -137,6 +145,8 @@
       <button class="side-btn" id="side-down2">↓</button>
       <button class="side-btn" id="side-left2">←</button>
       <button class="side-btn" id="side-right2">→</button>
+      <button class="side-btn" id="side-light2">明</button>
+      <button class="side-btn" id="side-dark2">暗</button>
     </div>
     <iframe id="camera-viewer2"
       src="http://{ipAddress}/ImageViewer?Mode=Motion&Resolution=640x360&Quality=Motion&Interval=10" scrolling="no">
@@ -176,6 +186,9 @@
     <h4 class="sukkiri">比率</h4>
     <button class="ifr-resize-btn sukkiri" id="wide-frame-size3">①</button>
     <button class="sukkiri ifr-resize-btn" id="small-frame-size3">②</button>
+    <h4 class="sukkiri">明るさ</h4>
+    <button class="light-btn sukkiri" id="light-btn3">明</button>
+    <button class="dark-btn sukkiri" id="dark-btn3">暗</button>
   </div>
   <div class="ping-panel sukkiri">
     <div class="online-status-indicatators3 sukkiri"></div>
@@ -196,6 +209,8 @@
       <button class="side-btn" id="side-down3">↓</button>
       <button class="side-btn" id="side-left3">←</button>
       <button class="side-btn" id="side-right3">→</button>
+      <button class="side-btn" id="side-light3">明</button>
+      <button class="side-btn" id="side-dark3">暗</button>
     </div>
     <iframe id="camera-viewer3"
       src="http://{ipAddress}/ImageViewer?Mode=Motion&Resolution=640x360&Quality=Motion&Interval=10" scrolling="no">
@@ -210,5 +225,6 @@
 </body>
 
 <p style="margin-bottom: 40rem;">
+<p style="margin-right: 40rem;">
 
 </html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,5 +1,27 @@
 'use strict'
 
+/*
+  ↓↓↓ TawaRemo Viewer全体に関係するコード（main.jsのみ記述) ↓↓↓
+*/
+//スクロール位置の保存
+let positionY;
+const scrollPositionKey = "scroll-position";
+
+function checkScrollPosition() {
+  positionY = window.pageYOffset;
+  localStorage.setItem(scrollPositionKey, positionY)
+}
+
+window.addEventListener("load", function() {
+  positionY = localStorage.getItem(scrollPositionKey);
+  //前回の保存データがあれば、スクロールする。
+  if(positionY !== null) {
+    scrollTo(0, positionY);
+  }
+  //スクロール時のイベント
+  window.addEventListener("scroll", checkScrollPosition, false);
+});
+
 //更新ボタン
 const reloadBtn = document.getElementById("reload-btn")
 const reloadText = document.getElementById("reload-text")
@@ -115,6 +137,10 @@ function loadUIState() {
 }
 loadUIState();
 
+/*
+  ↑↑↑ TawaRemo Viewer全体に関係するコード（main.jsのみ記述） ↑↑↑
+*/
+
 //ビューワーの拡大縮小ボタン
 const zoomInCameraBtn = document.getElementById("zoom-in-camera-btn")
 const zoomOutCameraBtn = document.getElementById("zoom-out-camera-btn")
@@ -210,6 +236,18 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 
+//明るさ調節のボタン
+const brighterBtn = document.getElementById("light-btn")
+const darkenBtn = document.getElementById("dark-btn")
+
+brighterBtn.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenBtn.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?bright=down";
+});
+
 //ビューワーサイドのボタン
 const angle1SideBtn = document.getElementById("side1")
 const angle2SideBtn = document.getElementById("side2")
@@ -220,6 +258,8 @@ const upSideBtn = document.getElementById("side-up")
 const downSideBtn = document.getElementById("side-down")
 const leftSideBtn = document.getElementById("side-left")
 const rightSideBtn = document.getElementById("side-right")
+const brighterSideBtn = document.getElementById("side-light")
+const darkenSideBtn = document.getElementById("side-dark")
 
 angle1SideBtn.addEventListener('click', () => {
   cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?preset=1";
@@ -255,4 +295,12 @@ leftSideBtn.addEventListener('click', () => {
 
 rightSideBtn.addEventListener('click', () => {
   cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?pan=1&tilt=0&Language=0";
+});
+
+brighterSideBtn.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenSideBtn.addEventListener('click', ()=> {
+  cameraViewer.src = "http://" + ipAddressInput.value + "/cgi-bin/camctrl?bright=down";
 });

--- a/web/main2.js
+++ b/web/main2.js
@@ -95,6 +95,19 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 
+//明るさ調節のボタン
+const brighterBtn2 = document.getElementById("light-btn2")
+const darkenBtn2 = document.getElementById("dark-btn2")
+
+brighterBtn2.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenBtn2.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?bright=down";
+});
+
+
 //ビューワーサイドのボタン
 const angle1SideBtn2 = document.getElementById("side1-2")
 const angle2SideBtn2 = document.getElementById("side2-2")
@@ -105,6 +118,8 @@ const upSideBtn2 = document.getElementById("side-up2")
 const downSideBtn2 = document.getElementById("side-down2")
 const leftSideBtn2 = document.getElementById("side-left2")
 const rightSideBtn2 = document.getElementById("side-right2")
+const brighterSideBtn2 = document.getElementById("side-light2")
+const darkenSideBtn2 = document.getElementById("side-dark2")
 
 angle1SideBtn2.addEventListener('click', () => {
   cameraViewer2.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?preset=1";
@@ -140,4 +155,12 @@ leftSideBtn2.addEventListener('click', () => {
 
 rightSideBtn2.addEventListener('click', () => {
   cameraViewer2.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?pan=1&tilt=0&Language=0";
+});
+
+brighterSideBtn2.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenSideBtn2.addEventListener('click', ()=> {
+  cameraViewer.src = "http://" + ipAddressInput2.value + "/cgi-bin/camctrl?bright=down";
 });

--- a/web/main3.js
+++ b/web/main3.js
@@ -95,6 +95,19 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 });
 
+//明るさ調節のボタン
+const brighterBtn3 = document.getElementById("light-btn3")
+const darkenBtn3 = document.getElementById("dark-btn3")
+
+brighterBtn3.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenBtn3.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?bright=down";
+});
+
+
 //ビューワーサイドのボタン
 const angle1SideBtn3 = document.getElementById("side1-3")
 const angle2SideBtn3 = document.getElementById("side2-3")
@@ -105,6 +118,8 @@ const upSideBtn3 = document.getElementById("side-up3")
 const downSideBtn3 = document.getElementById("side-down3")
 const leftSideBtn3 = document.getElementById("side-left3")
 const rightSideBtn3 = document.getElementById("side-right3")
+const brighterSideBtn3 = document.getElementById("side-light3")
+const darkenSideBtn3 = document.getElementById("side-dark3")
 
 angle1SideBtn3.addEventListener('click', () => {
   cameraViewer3.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?preset=1";
@@ -140,4 +155,12 @@ leftSideBtn3.addEventListener('click', () => {
 
 rightSideBtn3.addEventListener('click', () => {
   cameraViewer3.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?pan=1&tilt=0&Language=0";
+});
+
+brighterSideBtn3.addEventListener('click', () => {
+  cameraViewer.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?bright=up";
+});
+
+darkenSideBtn3.addEventListener('click', ()=> {
+  cameraViewer.src = "http://" + ipAddressInput3.value + "/cgi-bin/camctrl?bright=down";
 });

--- a/web/style.css
+++ b/web/style.css
@@ -196,6 +196,21 @@ input {
   color: #144998;
 }
 
+/*明るさ調整*/
+.light-btn,.dark-btn {
+  width: 2.1rem;
+  height: 1.6rem;
+  cursor: pointer;
+  justify-content: center;
+  align-items: center;
+  background: white;
+  color: black;
+  border-radius: 6%;
+  text-decoration: none;
+  border: outset 0.01px black;
+  margin-top: 1.25rem;
+}
+
 /*オンライン、オフライン*/
 .ping-panel {
   display: flex;


### PR DESCRIPTION
#24 
### 実装
・「明」「暗」ボタンと機能を実装
・他２つ機能を追加（スクロールバーの位置をローカルストレージへ保存、モニター横画面への対応）

### すっきりモードOFF
<img width="926" alt="スクリーンショット 2023-11-27 14 32 12" src="https://github.com/tigerscave/eight-eel-camera-viewer/assets/129372334/5fd3f450-3914-44ba-a7d7-56d8a7ce9a43">

### すっきりモードON
<img width="746" alt="スクリーンショット 2023-11-27 14 32 24" src="https://github.com/tigerscave/eight-eel-camera-viewer/assets/129372334/c9c189ad-0be2-4d79-ae2a-351ec2a64ac9">
